### PR TITLE
Add basic web UI for Kubernetes RTS game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # agi
+
+This repository contains a simple web-based UI for controlling a Kubernetes-backed RTS game. The interface lets you create server farms, scale them, and upgrade their container images via calls to a game server API.
+
+## UI
+
+Open `client/index.html` in a browser. Set the game server URL, then use the form to create farms or manage existing ones.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,96 @@
+async function apiFetch(path, options = {}) {
+  const base = document.getElementById('api-base').value.replace(/\/$/, '');
+  const res = await fetch(base + path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+async function loadFarms() {
+  try {
+    const farms = await apiFetch('/api/farms');
+    const tbody = document.getElementById('farm-list');
+    tbody.innerHTML = '';
+    farms.forEach(farm => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${farm.name}</td>
+        <td>${farm.replicas}</td>
+        <td>${farm.image}</td>
+        <td>
+          <button data-name="${farm.name}" class="scale-up">+1</button>
+          <button data-name="${farm.name}" class="scale-down">-1</button>
+          <button data-name="${farm.name}" class="upgrade">Upgrade</button>
+        </td>`;
+      tbody.appendChild(row);
+    });
+  } catch (err) {
+    alert('Failed to load farms: ' + err.message);
+  }
+}
+
+async function createFarm() {
+  const name = document.getElementById('farm-name').value.trim();
+  const image = document.getElementById('farm-image').value.trim();
+  const replicas = parseInt(document.getElementById('farm-replicas').value, 10);
+  if (!name) return alert('Name required');
+  try {
+    await apiFetch('/api/farms', {
+      method: 'POST',
+      body: JSON.stringify({ name, image, replicas }),
+    });
+    document.getElementById('farm-name').value = '';
+    loadFarms();
+  } catch (err) {
+    alert('Create failed: ' + err.message);
+  }
+}
+
+async function scaleFarm(name, delta) {
+  try {
+    await apiFetch(`/api/farms/${encodeURIComponent(name)}/scale`, {
+      method: 'POST',
+      body: JSON.stringify({ delta }),
+    });
+    loadFarms();
+  } catch (err) {
+    alert('Scale failed: ' + err.message);
+  }
+}
+
+async function upgradeFarm(name) {
+  const image = prompt('New container image:');
+  if (!image) return;
+  try {
+    await apiFetch(`/api/farms/${encodeURIComponent(name)}/upgrade`, {
+      method: 'POST',
+      body: JSON.stringify({ image }),
+    });
+    loadFarms();
+  } catch (err) {
+    alert('Upgrade failed: ' + err.message);
+  }
+}
+
+document.getElementById('refresh-btn').addEventListener('click', loadFarms);
+document.getElementById('create-btn').addEventListener('click', createFarm);
+
+document.getElementById('farm-list').addEventListener('click', (e) => {
+  const name = e.target.dataset.name;
+  if (!name) return;
+  if (e.target.classList.contains('scale-up')) {
+    scaleFarm(name, 1);
+  } else if (e.target.classList.contains('scale-down')) {
+    scaleFarm(name, -1);
+  } else if (e.target.classList.contains('upgrade')) {
+    upgradeFarm(name);
+  }
+});
+
+// Initial load
+loadFarms();

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kube RTS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Kubernetes RTS Controller</h1>
+
+  <section id="config">
+    <label for="api-base">Game server URL:</label>
+    <input id="api-base" type="text" value="http://localhost:8000" />
+    <button id="refresh-btn">Refresh Farms</button>
+  </section>
+
+  <section id="create-farm">
+    <h2>Create Server Farm</h2>
+    <input id="farm-name" type="text" placeholder="Farm name" />
+    <input id="farm-image" type="text" placeholder="Container image" value="mygame/bot:v1" />
+    <input id="farm-replicas" type="number" placeholder="Replicas" value="1" />
+    <button id="create-btn">Create</button>
+  </section>
+
+  <section id="farms">
+    <h2>Existing Farms</h2>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Replicas</th><th>Image</th><th>Actions</th></tr>
+      </thead>
+      <tbody id="farm-list"></tbody>
+    </table>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+section {
+  margin-bottom: 20px;
+}
+
+input {
+  margin-right: 5px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: left;
+}
+
+button {
+  margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- Add a simple HTML/JS UI to manage server farms in the Kubernetes-backed RTS concept
- Provide style and scripts to create, scale, and upgrade farms via REST calls
- Document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e48d47178832587921b03397bc451