### PR TITLE
Add basic web UI for Kubernetes RTS game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # agi
+
+This repository contains a simple web-based UI for controlling a Kubernetes-backed RTS game. The interface lets you create server farms, scale them, and upgrade their container images via calls to a game server API.
+
+## UI
+
+For full functionality you need a game server that communicates with a Kubernetes
+cluster. For local development or testing without a cluster, start the in-memory
+stub server:
+
+```
+npm run dev
+```
+
+This launches a Node.js server that serves the UI at `http://localhost:3000` and
+implements the `/api/*` endpoints purely in memory. Open that URL in a browser
+and play the game without touching a real cluster.
+
+## Tests
+
+Run `npm test` to execute a minimal smoke test that verifies the presence of key UI elements.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,101 @@
+const baseInput = document.getElementById('api-base');
+if (!baseInput.value) {
+  baseInput.value = window.location.origin;
+}
+
+async function apiFetch(path, options = {}) {
+  const base = baseInput.value.replace(/\/$/, '');
+  const res = await fetch(base + path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json();
+}
+
+async function loadFarms() {
+  try {
+    const farms = await apiFetch('/api/farms');
+    const tbody = document.getElementById('farm-list');
+    tbody.innerHTML = '';
+    farms.forEach(farm => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${farm.name}</td>
+        <td>${farm.replicas}</td>
+        <td>${farm.image}</td>
+        <td>
+          <button data-name="${farm.name}" class="scale-up">+1</button>
+          <button data-name="${farm.name}" class="scale-down">-1</button>
+          <button data-name="${farm.name}" class="upgrade">Upgrade</button>
+        </td>`;
+      tbody.appendChild(row);
+    });
+  } catch (err) {
+    alert('Failed to load farms: ' + err.message);
+  }
+}
+
+async function createFarm() {
+  const name = document.getElementById('farm-name').value.trim();
+  const image = document.getElementById('farm-image').value.trim();
+  const replicas = parseInt(document.getElementById('farm-replicas').value, 10);
+  if (!name) return alert('Name required');
+  try {
+    await apiFetch('/api/farms', {
+      method: 'POST',
+      body: JSON.stringify({ name, image, replicas }),
+    });
+    document.getElementById('farm-name').value = '';
+    loadFarms();
+  } catch (err) {
+    alert('Create failed: ' + err.message);
+  }
+}
+
+async function scaleFarm(name, delta) {
+  try {
+    await apiFetch(`/api/farms/${encodeURIComponent(name)}/scale`, {
+      method: 'POST',
+      body: JSON.stringify({ delta }),
+    });
+    loadFarms();
+  } catch (err) {
+    alert('Scale failed: ' + err.message);
+  }
+}
+
+async function upgradeFarm(name) {
+  const image = prompt('New container image:');
+  if (!image) return;
+  try {
+    await apiFetch(`/api/farms/${encodeURIComponent(name)}/upgrade`, {
+      method: 'POST',
+      body: JSON.stringify({ image }),
+    });
+    loadFarms();
+  } catch (err) {
+    alert('Upgrade failed: ' + err.message);
+  }
+}
+
+document.getElementById('refresh-btn').addEventListener('click', loadFarms);
+document.getElementById('create-btn').addEventListener('click', createFarm);
+
+document.getElementById('farm-list').addEventListener('click', (e) => {
+  const name = e.target.dataset.name;
+  if (!name) return;
+  if (e.target.classList.contains('scale-up')) {
+    scaleFarm(name, 1);
+  } else if (e.target.classList.contains('scale-down')) {
+    scaleFarm(name, -1);
+  } else if (e.target.classList.contains('upgrade')) {
+    upgradeFarm(name);
+  }
+});
+
+// Initial load
+loadFarms();

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kube RTS</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Kubernetes RTS Controller</h1>
+
+  <section id="config">
+    <label for="api-base">Game server URL:</label>
+    <input id="api-base" type="text" value="" />
+    <button id="refresh-btn">Refresh Farms</button>
+  </section>
+
+  <section id="create-farm">
+    <h2>Create Server Farm</h2>
+    <input id="farm-name" type="text" placeholder="Farm name" />
+    <input id="farm-image" type="text" placeholder="Container image" value="mygame/bot:v1" />
+    <input id="farm-replicas" type="number" placeholder="Replicas" value="1" />
+    <button id="create-btn">Create</button>
+  </section>
+
+  <section id="farms">
+    <h2>Existing Farms</h2>
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Replicas</th><th>Image</th><th>Actions</th></tr>
+      </thead>
+      <tbody id="farm-list"></tbody>
+    </table>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+section {
+  margin-bottom: 20px;
+}
+
+input {
+  margin-right: 5px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+  text-align: left;
+}
+
+button {
+  margin-right: 4px;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kubernetes-rts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+
+const farms = [];
+
+app.get('/api/farms', (req, res) => {
+  res.json(farms);
+});
+
+app.post('/api/farms', (req, res) => {
+  const { name, image = '', replicas = 1 } = req.body;
+  if (!name) return res.status(400).send('name required');
+  if (farms.some(f => f.name === name)) return res.status(409).send('farm exists');
+  farms.push({ name, image, replicas });
+  res.status(201).json({ ok: true });
+});
+
+app.post('/api/farms/:name/scale', (req, res) => {
+  const farm = farms.find(f => f.name === req.params.name);
+  if (!farm) return res.status(404).send('not found');
+  const delta = Number(req.body.delta) || 0;
+  farm.replicas = Math.max(0, farm.replicas + delta);
+  res.json(farm);
+});
+
+app.post('/api/farms/:name/upgrade', (req, res) => {
+  const farm = farms.find(f => f.name === req.params.name);
+  if (!farm) return res.status(404).send('not found');
+  const { image } = req.body;
+  if (!image) return res.status(400).send('image required');
+  farm.image = image;
+  res.json(farm);
+});
+
+app.use(express.static(path.join(__dirname, 'client')));
+
+app.listen(port, () => {
+  console.log(`Test server running at http://localhost:${port}`);
+});

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Basic test to ensure the UI markup includes the main header
+
+test('index.html contains header', async () => {
+  const html = await readFile(new URL('../client/index.html', import.meta.url), 'utf8');
+  assert.match(html, /Kubernetes RTS Controller/);
+});


### PR DESCRIPTION
## Summary
- Add an Express-based stub server that mimics Kubernetes actions for local testing
- Default UI's API base to the current origin for easier use with the stub server
- Document and script the new testing mode in package.json and the README

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_688e48d47178832587921b03397bc451